### PR TITLE
Fix N+1 query problem in few_tasks_left report

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -49,7 +49,7 @@ class ReportController < InheritedResources::Base
 
   def few_tasks_left
     @current_tab = :reports
-    base_query = Task.includes(:parent).where(kind_id: [1, 21],
+    base_query = Task.includes(:parent, :kind, :documents).where(kind_id: [1, 21],
                                               state: 'unassigned').group('parent_id').having('count(tasks.id) < 3').order(:name)
     @tasks = apply_scopes(base_query)
   end


### PR DESCRIPTION
## Summary
- Added `:kind` and `:documents` to eager loading in the `few_tasks_left` report method
- Prevents N+1 queries when rendering the report view

## Problem
The view template accesses `task.kind.try(:name)` and `task.percent_done` (which internally queries the documents association) for each task, causing N+1 query problems.

## Solution
Added `:kind` and `:documents` to the `includes` call in `report_controller.rb:52` to eager load these associations.

## Test Plan
- [ ] Visit the few_tasks_left report page
- [ ] Verify the page loads correctly
- [ ] Check database query logs to confirm no N+1 queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)