### PR TITLE
Fix document cloning to reset done flag

### DIFF
--- a/app/models/states.rb
+++ b/app/models/states.rb
@@ -182,6 +182,7 @@ module States
     parent.documents.each do |doc|
       d = doc.dup
       d.task_id = self.id
+      d.done = false
       d.file = Paperclip.io_adapters.for(doc.file)
       d.save
     end


### PR DESCRIPTION
## Summary
When cloning a task and its documents, the cloned documents now have their `done` flag set to `false` instead of copying the original value from the parent document.

## Changes
- Modified `clone_parent_documents` method in `app/models/states.rb` to explicitly set `done = false` for cloned documents

## Why This Is Needed
Previously, when a task was cloned along with its documents, the `done` flag was being copied from the original documents. This meant that if the parent task had documents marked as done, the cloned task would also have those documents marked as done, which is incorrect behavior. The cloned task should start fresh with all documents unmarked.

## Test Plan
- Existing model specs continue to pass
- The fix ensures that `doc.dup` behavior is overridden to explicitly set the `done` flag to `false`

Fixes: t-8a1

🤖 Generated with [Claude Code](https://claude.com/claude-code)