### PR TITLE
Fix volunteer anniversary email subject I18n pluralization

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -52,7 +52,7 @@ class Notification < ActionMailer::Base
     @message = message
     @years = user.years_since_joining
     @domain = domain
-    mail to: user.email_recipient, from: "Project Ben-Yehuda <editor@benyehuda.org>", subject: I18n.t('anniversary.email_subject', years: @years)
+    mail to: user.email_recipient, from: "Project Ben-Yehuda <editor@benyehuda.org>", subject: I18n.t('anniversary.email_subject', count: @years, years: @years)
   end
 
   def task_idle(task, assignee, editor)

--- a/spec/mailers/notification_spec.rb
+++ b/spec/mailers/notification_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :mailer do
+  describe '#anniversary_greeting' do
+    let(:sender) { create(:user, :editor, name: 'Editor Name') }
+    let(:message) { 'תודה על תרומתך!' }
+
+    context 'when user has been volunteering for 1 year' do
+      let(:user) { create(:user, :volunteer, name: 'Volunteer Name', created_at: 1.year.ago - 1.day) }
+
+      it 'uses singular form in subject line' do
+        mail = Notification.anniversary_greeting(user, sender, message)
+
+        expect(mail.subject).to eq('שנה של התנדבות בפרויקט בן־יהודה!')
+        expect(mail.subject).not_to include('{:one=>')
+        expect(mail.subject).not_to include(':other=>')
+      end
+    end
+
+    context 'when user has been volunteering for 3 years' do
+      let(:user) { create(:user, :volunteer, name: 'Volunteer Name', created_at: 3.years.ago - 1.day) }
+
+      it 'uses plural form in subject line with correct year count' do
+        mail = Notification.anniversary_greeting(user, sender, message)
+
+        expect(mail.subject).to eq('3 שנים של התנדבות בפרויקט בן־יהודה!')
+        expect(mail.subject).not_to include('{:one=>')
+        expect(mail.subject).not_to include(':other=>')
+      end
+    end
+
+    context 'when user has been volunteering for 5 years' do
+      let(:user) { create(:user, :volunteer, name: 'Volunteer Name', created_at: 5.years.ago - 1.day) }
+
+      it 'uses plural form in subject line with correct year count' do
+        mail = Notification.anniversary_greeting(user, sender, message)
+
+        expect(mail.subject).to eq('5 שנים של התנדבות בפרויקט בן־יהודה!')
+        expect(mail.subject).not_to include('{:one=>')
+        expect(mail.subject).not_to include(':other=>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the volunteer anniversary email subject line that was displaying raw I18n hash structure instead of properly localized Hebrew text.

## Problem

Volunteers were receiving anniversary emails with broken subject lines showing:
```
{:one=>"שנה של התנדבות בפרויקט בן־יהודה!", :other=>"%{years} שנים של התנדבות בפרויקט בן־יהודה!"}
```

## Root Cause

The `Notification#anniversary_greeting` method was calling `I18n.t()` with only the `years` parameter, but Rails I18n requires the `count` parameter to determine which plural form to use (`:one` vs `:other`).

## Solution

Added the `count` parameter to the I18n.t() call:
```ruby
# Before:
subject: I18n.t('anniversary.email_subject', years: @years)

# After:
subject: I18n.t('anniversary.email_subject', count: @years, years: @years)
```

Both parameters are needed:
- `count: @years` - triggers correct pluralization logic
- `years: @years` - interpolates the number into the translated string

## Changes

- **app/models/notification.rb:55** - Added `count` parameter to I18n.t() call
- **spec/mailers/notification_spec.rb** - New comprehensive test suite covering:
  - Singular form (1 year)
  - Plural forms (3 years, 5 years)
  - Verification that raw hash structure never appears

## Testing

All tests pass (35 examples, 0 failures):
```bash
bundle exec rspec spec/mailers/notification_spec.rb  # 3 examples, 0 failures
bundle exec rspec                                     # 35 examples, 0 failures
```

## Expected Results

After this fix, volunteers will receive properly localized subject lines:
- **1 year:** "שנה של התנדבות בפרויקט בן־יהודה!"
- **3+ years:** "3 שנים של התנדבות בפרויקט בן־יהודה!"

## Related

Closes issue t-fsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)