### PR TITLE
Use pdfunite for PDF-only downloads; stream single PDFs directly

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+require 'shellwords'
 require 'will_paginate/array' # for sorting the array when sorting by percent_done
 
 class TasksController < InheritedResources::Base
@@ -26,50 +27,71 @@ class TasksController < InheritedResources::Base
     if @task
       tmpfile = Tempfile.new(['dl_task_pdf__', '.pdf'])
       begin
-        jpegs = @task.documents.select { |x| x.file_file_name =~ /\.(jpg|jpeg|tif|JPG|JPEG|TIF|PNG|png|PDF|pdf)$/ }
+        docs = @task.documents.select { |x| x.file_file_name =~ /\.(jpg|jpeg|tif|JPG|JPEG|TIF|PNG|png|PDF|pdf)$/ }
         if params['dtype'].blank? || params['dtype'] == 'maintext'
-          jpegs = jpegs.select { |x| x.document_type == 'maintext' }
+          docs = docs.select { |x| x.document_type == 'maintext' }
         elsif params['dtype'] == 'front'
-          jpegs = jpegs.select { |x| x.document_type == 'front' }
+          docs = docs.select { |x| x.document_type == 'front' }
         elsif params['dtype'] == 'footnotes'
-          jpegs = jpegs.select { |x| x.document_type == 'footnotes_and_corrigenda' }
+          docs = docs.select { |x| x.document_type == 'footnotes_and_corrigenda' }
         else
           flash[:error] = 'התבקש סוג הורדה לא תקין'
           redirect_to task_path(@task)
           return
         end
-        if jpegs.empty?
+        if docs.empty?
           flash[:error] = 'אין סריקות מתאימות להורדה!'
           redirect_to task_path(@task)
           return
         end
-        tmpjpegs = []
-        jpegs.each do |jpeg|
-          jpegext = jpeg.file_file_name[jpeg.file_file_name.rindex('.')..-1]
-          tmpjpeg = Tempfile.new(['dl_task_jpg__', jpegext], binmode: true)
-          tmpjpegpath = tmpjpeg.path
-          tmpjpegs << tmpjpeg
-          response = HTTParty.get(jpeg.file.url)
-          tmpjpeg.write(response.body)
-          tmpjpeg.flush
-        end
+
+        has_images = docs.any? { |x| x.file_file_name =~ /\.(jpg|jpeg|tif|png)/i }
+
         tmpfilename = tmpfile.path
-        inputfiles = tmpfilename + '_input.txt'
-        # img2pdf needs NUL-separated list
-        File.open(inputfiles, 'w') do |f|
-          f.write(tmpjpegs.map do |tj|
-                    tj.path
-                  end.join("\0"))
+
+        if has_images
+          # Current behavior: convert images (and any PDFs) to a single PDF via img2pdf
+          tmpjpegs = []
+          docs.each do |jpeg|
+            jpegext = jpeg.file_file_name[jpeg.file_file_name.rindex('.')..-1]
+            tmpjpeg = Tempfile.new(['dl_task_jpg__', jpegext], binmode: true)
+            tmpjpegs << tmpjpeg
+            http_response = HTTParty.get(jpeg.file.url)
+            tmpjpeg.write(http_response.body)
+            tmpjpeg.flush
+          end
+          inputfiles = tmpfilename + '_input.txt'
+          # img2pdf needs NUL-separated list
+          File.open(inputfiles, 'w') do |f|
+            f.write(tmpjpegs.map(&:path).join("\0"))
+          end
+          # for this to work, ImageMagick must not restrict PDFs! See here: https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion
+          # ImageMagick was producing low-quality PDFs, so switched to img2pdf:
+          run_img2pdf(inputfiles, tmpfilename)
+          pdf = File.read(tmpfilename)
+          send_data pdf, type: 'application/pdf', filename: "Task_#{@task.id}.pdf"
+          File.delete(tmpfilename)
+          File.delete(inputfiles)
+        elsif docs.length == 1
+          # Single PDF: stream it directly without merging
+          http_response = HTTParty.get(docs.first.file.url)
+          send_data http_response.body, type: 'application/pdf', filename: "Task_#{@task.id}.pdf"
+        else
+          # PDF-only, multiple files: concatenate with pdfunite
+          tmppdfs = []
+          docs.each do |pdf_doc|
+            tmppdf = Tempfile.new(['dl_task_src_', '.pdf'], binmode: true)
+            tmppdfs << tmppdf
+            http_response = HTTParty.get(pdf_doc.file.url)
+            tmppdf.write(http_response.body)
+            tmppdf.flush
+          end
+          pdf_args = tmppdfs.map { |t| Shellwords.escape(t.path) }.join(' ')
+          run_pdfunite(pdf_args, tmpfilename)
+          pdf = File.read(tmpfilename)
+          send_data pdf, type: 'application/pdf', filename: "Task_#{@task.id}.pdf"
+          File.delete(tmpfilename)
         end
-        # run the conversion
-        # for this to work, ImageMagick must not restrict PDFs! See here: https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion
-        # `convert @#{inputfiles} #{tmpfilename}`
-        # ImageMagick was producing low-quality PDFs, so switched to img2pdf:
-        `img2pdf --from-file #{inputfiles} -o #{tmpfilename}`
-        pdf = File.read(tmpfilename)
-        send_data pdf, type: 'application/pdf', filename: "Task_#{@task.id}.pdf"
-        File.delete(tmpfilename) # delete temporary generated PDF
-        File.delete(inputfiles)
       rescue StandardError
         redirect_to '/'
       ensure
@@ -245,5 +267,13 @@ class TasksController < InheritedResources::Base
 
   def task_params
     params.permit!
+  end
+
+  def run_img2pdf(input_list_file, output_path)
+    `img2pdf --from-file #{input_list_file} -o #{Shellwords.escape(output_path)}`
+  end
+
+  def run_pdfunite(pdf_args, output_path)
+    `pdfunite #{pdf_args} #{Shellwords.escape(output_path)}`
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,4 @@
 require 'httparty'
-require 'shellwords'
 require 'will_paginate/array' # for sorting the array when sorting by percent_done
 
 class TasksController < InheritedResources::Base
@@ -52,11 +51,11 @@ class TasksController < InheritedResources::Base
         if has_images
           # Current behavior: convert images (and any PDFs) to a single PDF via img2pdf
           tmpjpegs = []
-          docs.each do |jpeg|
-            jpegext = jpeg.file_file_name[jpeg.file_file_name.rindex('.')..-1]
-            tmpjpeg = Tempfile.new(['dl_task_jpg__', jpegext], binmode: true)
+          docs.each do |doc|
+            docext = doc.file_file_name[doc.file_file_name.rindex('.')..-1]
+            tmpjpeg = Tempfile.new(['dl_task_jpg__', docext], binmode: true)
             tmpjpegs << tmpjpeg
-            http_response = HTTParty.get(jpeg.file.url)
+            http_response = HTTParty.get(doc.file.url)
             tmpjpeg.write(http_response.body)
             tmpjpeg.flush
           end
@@ -86,8 +85,7 @@ class TasksController < InheritedResources::Base
             tmppdf.write(http_response.body)
             tmppdf.flush
           end
-          pdf_args = tmppdfs.map { |t| Shellwords.escape(t.path) }.join(' ')
-          run_pdfunite(pdf_args, tmpfilename)
+          run_pdfunite(tmppdfs.map(&:path), tmpfilename)
           pdf = File.read(tmpfilename)
           send_data pdf, type: 'application/pdf', filename: "Task_#{@task.id}.pdf"
           File.delete(tmpfilename)
@@ -270,10 +268,10 @@ class TasksController < InheritedResources::Base
   end
 
   def run_img2pdf(input_list_file, output_path)
-    `img2pdf --from-file #{input_list_file} -o #{Shellwords.escape(output_path)}`
+    system('img2pdf', '--from-file', input_list_file, '-o', output_path) || raise('img2pdf failed')
   end
 
-  def run_pdfunite(pdf_args, output_path)
-    `pdfunite #{pdf_args} #{Shellwords.escape(output_path)}`
+  def run_pdfunite(pdf_paths, output_path)
+    system('pdfunite', *pdf_paths, output_path) || raise('pdfunite failed')
   end
 end

--- a/spec/requests/tasks_download_pdf_spec.rb
+++ b/spec/requests/tasks_download_pdf_spec.rb
@@ -1,0 +1,132 @@
+# encoding: utf-8
+# Tests for the download_pdf action: PDF-only tasks use pdfunite; image tasks use img2pdf.
+# A single PDF is passed through directly; a single image still uses img2pdf.
+require 'rails_helper'
+
+RSpec.describe 'Tasks download_pdf', type: :request do
+  let(:editor)    { create(:user, :editor, :active_user) }
+  let(:volunteer) { create(:user, :volunteer, :active_user) }
+  let(:task)      { create(:task, state: 'approved', editor: editor, assignee: volunteer) }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:require_user).and_return(true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(editor)
+    allow_any_instance_of(Task).to receive(:participant?).and_return(true)
+    allow_any_instance_of(Task).to receive(:delayed_notify_on_changes)
+    # S3 bucket is nil in test env; stub file.url so it doesn't raise
+    allow_any_instance_of(Paperclip::Attachment).to receive(:url).and_return('http://example.com/fake.pdf')
+    allow(HTTParty).to receive(:get).and_return(double('resp', body: '%PDF-1.4 fake'))
+  end
+
+  def add_doc(task, filename, doc_type: 'maintext')
+    create(:document,
+           task: task,
+           file_file_name: filename,
+           file_content_type: 'application/octet-stream',
+           file_file_size: 100,
+           document_type: doc_type,
+           user_id: volunteer.id)
+  end
+
+  def stub_img2pdf_ok
+    allow_any_instance_of(TasksController).to receive(:run_img2pdf) do |_ctrl, _input, output|
+      File.write(output, '%PDF-1.4 img2pdf-generated')
+    end
+  end
+
+  def stub_pdfunite_ok
+    allow_any_instance_of(TasksController).to receive(:run_pdfunite) do |_ctrl, _args, output|
+      File.write(output, '%PDF-1.4 pdfunite-merged')
+    end
+  end
+
+  context 'when a single PDF document exists' do
+    before { add_doc(task, 'solo.pdf') }
+
+    it 'streams the PDF directly without merging' do
+      expect_any_instance_of(TasksController).not_to receive(:run_pdfunite)
+      expect_any_instance_of(TasksController).not_to receive(:run_img2pdf)
+
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+
+      expect(response.content_type).to eq('application/pdf')
+    end
+  end
+
+  context 'when all documents are PDFs (multiple)' do
+    before { add_doc(task, 'scan1.pdf') && add_doc(task, 'scan2.pdf') }
+
+    it 'uses pdfunite to concatenate the PDFs' do
+      pdfunite_called = false
+      allow_any_instance_of(TasksController).to receive(:run_pdfunite) do |_ctrl, _args, output|
+        pdfunite_called = true
+        File.write(output, '%PDF-1.4 merged')
+      end
+
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+
+      expect(pdfunite_called).to be true
+    end
+
+    it 'does not call img2pdf' do
+      stub_pdfunite_ok
+      expect_any_instance_of(TasksController).not_to receive(:run_img2pdf)
+
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+    end
+
+    it 'returns a PDF response' do
+      stub_pdfunite_ok
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+      expect(response.content_type).to eq('application/pdf')
+    end
+  end
+
+  context 'when documents include JPEG images' do
+    before { add_doc(task, 'scan1.jpg') && add_doc(task, 'scan2.jpg') }
+
+    it 'uses img2pdf for conversion' do
+      img2pdf_called = false
+      allow_any_instance_of(TasksController).to receive(:run_img2pdf) do |_ctrl, _input, output|
+        img2pdf_called = true
+        File.write(output, '%PDF-1.4 generated')
+      end
+
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+
+      expect(img2pdf_called).to be true
+    end
+
+    it 'does not call pdfunite' do
+      stub_img2pdf_ok
+      expect_any_instance_of(TasksController).not_to receive(:run_pdfunite)
+
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+    end
+  end
+
+  context 'when documents include PNG images alongside a PDF' do
+    before { add_doc(task, 'scan.png') && add_doc(task, 'appendix.pdf') }
+
+    it 'uses img2pdf (image path) rather than pdfunite' do
+      img2pdf_called = false
+      allow_any_instance_of(TasksController).to receive(:run_img2pdf) do |_ctrl, _input, output|
+        img2pdf_called = true
+        File.write(output, '%PDF-1.4 generated')
+      end
+
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+
+      expect(img2pdf_called).to be true
+    end
+  end
+
+  context 'when there are no matching image or PDF documents' do
+    before { add_doc(task, 'report.docx') }
+
+    it 'redirects back to the task with an error' do
+      get task_download_pdf_path(task), params: { dtype: 'maintext' }
+      expect(response).to redirect_to(task_path(task))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- When all of a task's filtered documents are PDFs (no JPEG/PNG/TIF images), concatenate them natively with `pdfunite` instead of `img2pdf` (which is image-only). `pdfunite` is already installed via poppler-utils.
- When exactly one PDF document exists, stream it directly to the browser — no merging tool needed.
- When any image attachment is present, the existing `img2pdf` path is used unchanged.
- Non-image, non-PDF files (DOCX etc.) continue to be ignored when making the determination.
- Extracts shell calls into `run_img2pdf` / `run_pdfunite` private helpers for testability.
- Fixed a local variable name collision (`response` shadowing the controller method).

## Test plan

- [x] New request spec `spec/requests/tasks_download_pdf_spec.rb` covers all branches: single PDF passthrough, multi-PDF pdfunite, JPEG→img2pdf, mixed PNG+PDF→img2pdf, DOCX-only→error redirect.
- [x] All 40 existing tests still pass (`bundle exec rspec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)