### PR TITLE
Fix off-by-one in anniversary greeting year count

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,9 +293,13 @@ class User < ActiveRecord::Base
   end
 
   # Anniversary-related methods
+  # The anniversary being marked, i.e. the calendar-year difference: a volunteer who
+  # joined in 2020 is marking six years in 2026. Greetings go out within a week on
+  # either side of the anniversary date, so counting fully elapsed years would be off
+  # by one for everyone greeted before their anniversary date itself.
   def years_since_joining
     return 0 if created_at.nil?
-    ((Time.zone.now - created_at) / 1.year).floor
+    Time.zone.now.year - created_at.year
   end
 
   def near_anniversary?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -384,4 +384,41 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#years_since_joining' do
+    around do |example|
+      travel_to(Time.zone.local(2026, 2, 15, 12, 0, 0)) do
+        example.run
+      end
+    end
+
+    it 'counts the anniversary about to be marked, for volunteers greeted before their anniversary date' do
+      # Joined 2020-02-20: their sixth anniversary is 5 days away, within the greeting window
+      volunteer = create(:user, :volunteer, :active_user,
+                         created_at: Time.zone.local(2020, 2, 20, 12, 0, 0))
+
+      expect(volunteer.years_since_joining).to eq(6)
+    end
+
+    it 'counts the anniversary just marked, for volunteers greeted after their anniversary date' do
+      # Joined 2020-02-10: their sixth anniversary was 5 days ago, within the greeting window
+      volunteer = create(:user, :volunteer, :active_user,
+                         created_at: Time.zone.local(2020, 2, 10, 12, 0, 0))
+
+      expect(volunteer.years_since_joining).to eq(6)
+    end
+
+    it 'counts a single year on the first anniversary' do
+      volunteer = create(:user, :volunteer, :active_user,
+                         created_at: Time.zone.local(2025, 2, 15, 12, 0, 0))
+
+      expect(volunteer.years_since_joining).to eq(1)
+    end
+
+    it 'returns 0 when created_at is unknown' do
+      volunteer = build(:user, :volunteer, created_at: nil)
+
+      expect(volunteer.years_since_joining).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`User#years_since_joining` counted **fully elapsed** years (`((Time.zone.now - created_at) / 1.year).floor`). Anniversary greetings go out within a 7-day window on *either* side of the anniversary date, so every volunteer greeted *before* their anniversary date was told they had volunteered one year fewer than they had — a volunteer who joined in 2020 was greeted with "five years" in 2026 instead of six.

The same count feeds three places: the dashboard anniversary list (`_anniversary_users.html.haml`, including the pre-filled greeting message), the greeting email (`Notification#anniversary_greeting`), and the in-app flash (`ApplicationController#check_anniversary`).

## Fix

Count the anniversary being marked — the calendar-year difference — rather than fully elapsed years. Within the greeting window this is exactly the anniversary number in both directions (5 days before and 5 days after the date both yield 6 for a 2020 joiner).

## Tests

Added `describe '#years_since_joining'` in `spec/models/user_spec.rb` with time frozen at 2026-02-15: before the anniversary, after the anniversary, the first anniversary, and the nil `created_at` guard. Two of the four fail against the old implementation.

- `bundle exec rspec spec/models/user_spec.rb` — 38 examples, 0 failures
- `bundle exec rspec --exclude-pattern "lib/**/*_spec.rb"` — 248 examples, 2 failures, both pre-existing in `spec/system/image_cropping_spec.rb` and reproducible on master without this change

Note: a plain `bundle exec rspec` run stops after the `spec/lib` page-validation specs and reports only ~40 of 262 examples, which is why the run above excludes them. Filed separately as beads `t-3dw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)