### PR TITLE
Fix rspec suite silently aborting after the spec/lib page-validation specs

### DIFF
--- a/lib/tasks/validate_scans.rake
+++ b/lib/tasks/validate_scans.rake
@@ -22,11 +22,10 @@ task :validate_scans, [:scan_dir] => :environment do |taskname, args|
 
   if image_files.empty?
     puts "No image files found in #{scan_dir}"
-    exit 0
+  else
+    puts "Found #{image_files.length} image files"
+    puts "Extracting page numbers..."
   end
-
-  puts "Found #{image_files.length} image files"
-  puts "Extracting page numbers..."
 
   # Store results: filename => page_number (or nil if unknown)
   results = {}

--- a/spec/lib/tasks/validate_scans_spec.rb
+++ b/spec/lib/tasks/validate_scans_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe 'validate_scans rake task', type: :task do
       expect(report).to include("Total files: 0")
     end
 
+    # Regression: the task used to call `exit 0` when it found no images, which
+    # terminated the whole rspec process and silently hid the rest of the suite.
+    it 'does not exit the process when no image files are found' do
+      expect { task.invoke(test_dir) }.not_to raise_error
+    end
+
     it 'uses default directory when no argument provided' do
       FileUtils.mkdir_p('tmp/scans')
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,4 +72,15 @@ RSpec.configure do |config|
 
   # Include ActiveSupport time helpers for time travel in tests
   config.include ActiveSupport::Testing::TimeHelpers
+
+  # RSpec deliberately does not rescue SystemExit, so code under test that calls
+  # Kernel#exit (e.g. a rake task) kills the whole run mid-suite, and the at_exit
+  # summary still reports "0 failures" for the examples that did run. Turn such an
+  # exit into an ordinary example failure so the rest of the suite keeps running.
+  config.around do |example|
+    example.run
+  rescue SystemExit => e
+    raise "Example called Kernel#exit(#{e.status}); code under test must not exit the process. " \
+          "Wrap the call in `expect { ... }.to raise_error(SystemExit)` if the exit is intentional."
+  end
 end


### PR DESCRIPTION
## Problem (t-3dw)

`bundle exec rspec` reported "12 examples, 0 failures" and exited **0**, while `--dry-run` counted 262. Everything after `spec/lib` — models, requests, services, system specs — never ran and never reported.

Root cause: the `validate_scans` rake task calls `exit 0` when it finds no image files. RSpec deliberately does not rescue `SystemExit`, so the `handles empty directory` example terminated the rspec process outright; rspec's `at_exit` hook then printed a summary for the handful of examples that had run, with a clean exit status. Silent, and green.

## Changes

- **`lib/tasks/validate_scans.rake`** — on an empty directory, print the message and fall through to normal report generation instead of `exit 0`. The task now returns normally and still writes a `Total files: 0` report. (The `exit 1` for a genuinely missing directory is left alone; that's legitimate CLI behaviour and is already covered by a spec that expects `SystemExit`.)
- **`spec/rails_helper.rb`** — an `around` hook converts a `SystemExit` escaping an example into an ordinary example failure. A future stray `exit` in code under test now fails loudly on that one example instead of truncating the suite behind a "0 failures" banner.
- **`spec/lib/tasks/validate_scans_spec.rb`** — regression test: the task must not exit the process when no image files are found.

## Test plan

- Before: `bundle exec rspec` → `12 examples, 0 failures`, exit 0 (suite truncated).
- After: `bundle exec rspec` → **263 examples, 2 failures, 18 pending**, exit 1.
- `bundle exec rspec spec/lib` → 15 examples, 0 failures.
- Verified the new guard works with a throwaway spec calling `exit 0`: that example is reported as a failure and the following example still runs.

### About the 2 remaining failures

Both are in `spec/system/image_cropping_spec.rb` and are **pre-existing, not caused by this PR** — they had simply never been executed, because `spec/lib` sorts before `spec/system` and the run died there. Filed as bead **t-c02** (`discovered-from: t-3dw`) with a diagnosis of all four distinct problems in that file (missing `TaskState` records, `let` that should be `let!`, a jQuery-UI theme asset 404 tripping `Capybara.raise_server_errors`, and the viewport assertion itself). Kept out of this PR to keep it focused on the suite-abort fix.

Closes t-3dw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)